### PR TITLE
fix: markdown table

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -117,6 +117,8 @@ TODO
 
 TODO
 
+| Platform | link |
+| ---- | ---- |
 |Google+ URL| |
 |Twitter URL| https://twitter.com/ClojureGSoC |
 |Blog URL| http://clojure-gsoc.org/|

--- a/profile.md
+++ b/profile.md
@@ -1,15 +1,16 @@
 Public Profile
 ==============
 
-|Name                        |Clojure                                           |
-|Website URL                 |http://clojure-gsoc.org                           |
-|Tagline                     |Supporting the Clojure and ClojureScript ecosystem|
-|Logo                        |![Clojure logo](https://static1.squarespace.com/static/5372821be4b0aefc6719057e/t/56a8f163bfe873fb103cfc05/1453912453874/?format=300w)      |
-|Primary Open Source License:|Eclipse Public License 1.0 (EPL-1.0)              |
-|Organization Category       |Programming Languages and Development Tools       |
-|Technology Tags             |Clojure,ClojureScript,JavaScript,JVM,functional programming|
-|Topic Tags                  |programming language, development tools, compilers, functional programming, build systesm|
-|Ideas List                  |http://clojure-gsoc.org/project-ideas.html        |
+| Name                        | Clojure                                           |
+| ---- | ----- |
+| Website URL                 | http://clojure-gsoc.org                           |
+| Tagline                     | Supporting the Clojure and ClojureScript ecosystem|
+| Logo                        | ![Clojure logo](https://static1.squarespace.com/static/5372821be4b0aefc6719057e/t/56a8f163bfe873fb103cfc05/1453912453874/?format=300w)      |
+| Primary Open Source License:| Eclipse Public License 1.0 (EPL-1.0)              |
+| Organization Category       | Programming Languages and Development Tools       |
+| Technology Tags             | Clojure,ClojureScript,JavaScript,JVM,functional programming |
+| Topic Tags                  | programming language, development tools, compilers, functional programming, build systesm |
+| Ideas List                  | http://clojure-gsoc.org/project-ideas.html        |
 
 
 ## Descriptions

--- a/profile.md
+++ b/profile.md
@@ -50,7 +50,7 @@ Clojure, as a GSoC mentoring organization, includes projects from all parts of t
 > Examples: New Feature, Optimization. You can also use these to designate “sub-organizations” if you are an umbrella organization.
 
 
-### Application insturctions
+### Application instructions
 
 *1500 Characters*
 
@@ -106,9 +106,12 @@ Clojure, as a GSoC mentoring organization, includes projects from all parts of t
 
 TODO
 
-|Chat         |http://clojurians.net/                |
-|Mailing list |http://groups.google.com/group/clojure|
-|General Email|                                      |
+
+| Method | link |
+| ---- | ----- |
+| Chat         |http://clojurians.net/                |
+| Mailing list |http://groups.google.com/group/clojure|
+| General Email|                                      |
 
 ## Links
 


### PR DESCRIPTION
missing separator line